### PR TITLE
crossScalaVersions += 2.13.0

### DIFF
--- a/src/main/scala/io/kamon/sbt/umbrella/KamonSbtUmbrella.scala
+++ b/src/main/scala/io/kamon/sbt/umbrella/KamonSbtUmbrella.scala
@@ -110,11 +110,11 @@ object KamonSbtUmbrella extends AutoPlugin {
   }
 
   private def scalaVersionSetting = Def.setting {
-    if (sbtPlugin.value) scalaVersion.value else "2.12.8"
+    if (sbtPlugin.value) scalaVersion.value else "2.13.0"
   }
 
   private def crossScalaVersionsSetting = Def.setting {
-    if (sbtPlugin.value) Seq(scalaVersion.value) else Seq("2.11.12", "2.12.8")
+    if (sbtPlugin.value) Seq(scalaVersion.value) else Seq("2.11.12", "2.12.8", "2.13.0")
   }
 
   def findKanelaAgentJar = Def.task {


### PR DESCRIPTION
I'm coming at this a bit naive, but I see the desire to support 2.13.0 in https://github.com/kamon-io/Kamon/pull/590.

Scala 2.13 is the current version, so maybe it's reasonable to add it as default in the umbrella, and override back down to the subset that older versions of play support.

I'd be interesting in helping port the other modules.

What do you think @ivantopo?